### PR TITLE
New `findOne` method, and refactored and tested the `find` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,54 @@
 # Dynatable
-A wrapper for DynamoDB tables, with a promise wrapped simplified API for the AWS SDK's DynamoDB.DocumentClient.
+A DynamoDB table wrapper with a promise wrapped simplified API for the AWS SDK's DynamoDB.DocumentClient.
 
+## Why?
+DynamoDB.DocumentClient is the official way to talk to your DynamoDB databases, but the API is a little clunky and not very JavaScripty.
 
+Dynatable gives you an easier to use API which borrows a little inspiration from MongoDB.
 
 ## Usage
 ```
 const AWS = require('aws-sdk');
 const dynatable = require('dynatable');
+
+AWS.config.update({
+  region: "eu-west-1",
+  accessKeyId: "AKIAJX24PKMIEKUZBY3Q",
+  secretAccessKey: "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"
+});
 const docClient = new AWS.DynamoDB.DocumentClient();
 
-// Imagine you have a DynamoDB table called `users`
-const users = dynatable(docClient, 'users');
+// Imagine you have a table called `users`, which is set up with an `id` key in DynamoDB
+const users = dynatable(docClient, 'users', { id: 'N' });
+
+// You now have
 users.get({ id: 1 })
   .then(users => console.log(users));
 // [{ id: 1, name: 'Dynatable', interests: 'API wrapping, getting, putting, updating and deleting'}]
+```
+
+Or the way I use it, define (and export) all tables of your project in one file, and then import them where needed:
+
+**tables.js**
+```
+// all the setup from the previous example here
+
+export const userTable = dynatable(docClient, 'users', { id: 'N' });
+export const postTable = dynatable(docClient, 'users', { id: 'N' });
+```
+
+**posts.js**
+```
+import { userTable, postTable } from './tables';
+
+// Get user details
+const userDetails = userTable.findOne({ id: userId });
+
+// Get user's post
+const userPosts = postTable.find({ userId });
+
+Promise.all([ userDetails, userPosts ])
+  .then(([details, posts]) => {
+    // Do something with details and posts here
+  });
 ```

--- a/src/find.js
+++ b/src/find.js
@@ -2,8 +2,7 @@ import promiseWrapper from './promise-wrapper';
 import { splitKeysAndParams, createFilterQuery } from './query';
 import { isObject } from './util';
 
-export default function find({ docClient, TableName, params, tableKeyDefinition }) {
-  console.log('find', TableName, tableKeyDefinition);
+export function find({ docClient, TableName, params, tableKeyDefinition }) {
   const [Key, scanParams] = splitKeysAndParams(params, tableKeyDefinition);
 
   // If we have any params that aren't `key` attributes in the table we
@@ -11,11 +10,30 @@ export default function find({ docClient, TableName, params, tableKeyDefinition 
   if (isObject(scanParams) && Object.keys(scanParams).length > 0) {
     return promiseWrapper(docClient, 'scan', Object.assign({
       TableName,
-    }, createFilterQuery(scanParams)));
+    }, createFilterQuery(scanParams)))
+      .then(handleFindResults);
   }
 
   return promiseWrapper(docClient, 'get', {
     TableName,
     Key,
-  });
+  })
+    .then(handleFindResults);
+}
+
+export function findOne({ docClient, TableName, params, tableKeyDefinition }) {
+  return find({ docClient, TableName, params, tableKeyDefinition })
+    .then(res => res && res[0] || null);
+}
+
+function handleFindResults(res) {
+  // Ensure that the response has either of the data properties, otherwise return an empty array
+  if (!res.Items && !res.Item) {
+    return [];
+  }
+
+  // Ensure that `.find()` always returns an array
+  // `.get()` will return an Item prop with a single object
+  // `.scan()` will return an Items prop with one or more objects
+  return res.Items ? res.Items : [ res.Item ];
 }

--- a/src/find.test.js
+++ b/src/find.test.js
@@ -49,8 +49,22 @@ describe('find', () => {
     };
 
     find({ docClient, TableName, tableKeyDefinition, params: { id: 5 } })
-      .then(res => expect(Array.isArray(res)).toBeTruthy());
+      .then(res => expect(Array.isArray(res) && res.length === 1).toBeTruthy());
     find({ docClient, TableName, tableKeyDefinition, params: { id: 5, isPirple: 'huh?' } })
-      .then(res => expect(Array.isArray(res)).toBeTruthy());
+      .then(res => expect(Array.isArray(res) && res.length === 2).toBeTruthy());
+  });
+
+  it('Should return an empty array when resolved without Item or Items keys', () => {
+    docClient = {
+      get: jest.fn((params, cb) => cb(null, { id: 1 })),
+      scan: jest.fn((params, cb) => cb(null,
+        [ { id: 1 }, { id: 2 } ]
+      )),
+    };
+
+    find({ docClient, TableName, tableKeyDefinition, params: { id: 5 } })
+      .then(res => expect(Array.isArray(res) && res.length === 0).toBeTruthy());
+    find({ docClient, TableName, tableKeyDefinition, params: { id: 5, isPirple: 'huh?' } })
+      .then(res => expect(Array.isArray(res) && res.length === 0).toBeTruthy());
   });
 });

--- a/src/find.test.js
+++ b/src/find.test.js
@@ -17,9 +17,20 @@ describe('find', () => {
 
   it('Should reject on callback errors', () => {
     docClient = {
-      get: jest.fn((params, cb) => cb('Something went wrong'))
+      get: jest.fn((params, cb) => cb('Something went wrong')),
     };
     find({ docClient, TableName, tableKeyDefinition, params })
       .catch(err => expect(err).toBeDefined());
+  });
+
+  it('Should call `get` for table keys and `scan` for other keys', () => {
+    docClient = {
+      get: jest.fn(),
+      scan: jest.fn(),
+    };
+    find({ docClient, TableName, tableKeyDefinition, params: { id: 5 } });
+    expect(docClient.get.mock.calls.length).toBe(1);
+    find({ docClient, TableName, tableKeyDefinition, params: { blorg: 5 } });
+    expect(docClient.scan.mock.calls.length).toBe(1);
   });
 });

--- a/src/find.test.js
+++ b/src/find.test.js
@@ -68,3 +68,35 @@ describe('find', () => {
       .then(res => expect(Array.isArray(res) && res.length === 0).toBeTruthy());
   });
 });
+
+describe('findOne', () => {
+  it('Should return the first item', () => {
+    docClient = {
+      get: jest.fn((params, cb) => cb(null, {
+        Item: { id: 1 }
+      })),
+      scan: jest.fn((params, cb) => cb(null, {
+        Items: [ { id: 1 }, { id: 2 } ]
+      })),
+    };
+
+    findOne({ docClient, TableName, tableKeyDefinition, params: { id: 1 } })
+      .then(res => expect(res).toEqual({ id: 1 }));
+    findOne({ docClient, TableName, tableKeyDefinition, params: { id: 1, whois: 'Mr. Poopybutthole' } })
+      .then(res => expect(res).toEqual({ id: 1 }));
+  });
+
+  it('Should return null when no result', () => {
+    docClient = {
+      get: jest.fn((params, cb) => cb(null, {})),
+      scan: jest.fn((params, cb) => cb(null, {
+        Items: []
+      })),
+    };
+
+    findOne({ docClient, TableName, tableKeyDefinition, params: { id: 1 } })
+      .then(res => expect(res).toBe(null));
+    findOne({ docClient, TableName, tableKeyDefinition, params: { id: 1, whois: 'Mr. Poopybutthole' } })
+      .then(res => expect(res).toBe(null));
+  });
+});

--- a/src/find.test.js
+++ b/src/find.test.js
@@ -2,7 +2,7 @@ import { find, findOne } from './find';
 
 let docClient;
 let TableName = 'w00t';
-let tableKeyDefinition = { id: 'N' };
+let tableKeyDefinition = { id: 'N', name: 'S' };
 let params = { id: 1 };
 
 describe('find', () => {
@@ -32,5 +32,9 @@ describe('find', () => {
     expect(docClient.get.mock.calls.length).toBe(1);
     find({ docClient, TableName, tableKeyDefinition, params: { blorg: 5 } });
     expect(docClient.scan.mock.calls.length).toBe(1);
+    find({ docClient, TableName, tableKeyDefinition, params: { id: 5, name: 'Pony' } });
+    expect(docClient.get.mock.calls.length).toBe(2);
+    find({ docClient, TableName, tableKeyDefinition, params: { id: 5, name: 'Pony', isPink: true } });
+    expect(docClient.scan.mock.calls.length).toBe(2);
   });
 });

--- a/src/find.test.js
+++ b/src/find.test.js
@@ -1,0 +1,25 @@
+import { find, findOne } from './find';
+
+let docClient;
+let TableName = 'w00t';
+let tableKeyDefinition = { id: 'N' };
+let params = { id: 1 };
+
+describe('find', () => {
+  it('Should reject when docClient is invalid', () => {
+    docClient = null;
+    find({ docClient, TableName, tableKeyDefinition, params })
+      .catch(err => expect(err).toBeDefined());
+    docClient = {};
+    find({ docClient, TableName, tableKeyDefinition, params })
+      .catch(err => expect(err).toBeDefined());
+  });
+
+  it('Should reject on callback errors', () => {
+    docClient = {
+      get: jest.fn((params, cb) => cb('Something went wrong'))
+    };
+    find({ docClient, TableName, tableKeyDefinition, params })
+      .catch(err => expect(err).toBeDefined());
+  });
+});

--- a/src/find.test.js
+++ b/src/find.test.js
@@ -37,4 +37,20 @@ describe('find', () => {
     find({ docClient, TableName, tableKeyDefinition, params: { id: 5, name: 'Pony', isPink: true } });
     expect(docClient.scan.mock.calls.length).toBe(2);
   });
+
+  it('Should return an array if resolved', () => {
+    docClient = {
+      get: jest.fn((params, cb) => cb(null, {
+        Item: { id: 1 }
+      })),
+      scan: jest.fn((params, cb) => cb(null, {
+        Items: [ { id: 1 }, { id: 2 } ]
+      })),
+    };
+
+    find({ docClient, TableName, tableKeyDefinition, params: { id: 5 } })
+      .then(res => expect(Array.isArray(res)).toBeTruthy());
+    find({ docClient, TableName, tableKeyDefinition, params: { id: 5, isPirple: 'huh?' } })
+      .then(res => expect(Array.isArray(res)).toBeTruthy());
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
 import promiseWrapper from './promise-wrapper';
 import { splitKeysAndParams } from './query';
 import { isObject } from './util';
-import find from './find';
+import { find, findOne } from './find';
 
 export default function tableWrapper(docClient, TableName, tableKeyDefinition) {
   const tableParams = { docClient, TableName, tableKeyDefinition };
   return {
     find: params => find(Object.assign({}, tableParams, { params })),
+    findOne: params => findOne(Object.assign({}, tableParams, { params })),
     put: params => promiseWrapper(docClient, 'put', {
       TableName,
       Item: params,


### PR DESCRIPTION
This PR adds a new `findOne` method, which will return the first result of any result set, or null if no results.

Also refactored the `find` module to not export the `find` function as default, but a named export.

Added tests for both `find` and `findOne`.