### PR TITLE
Empty/All queries

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33,9 +33,9 @@ var valuePrefix = ':dt';
 // and another object for all other params
 // ({id: 1, name: 'pony', interests: 'ponying'}, { id: 'N' }) -> [{id: 1}, {name: 'pony', interests: 'ponying'}]
 function splitKeysAndParams(params, tableKeys) {
-  if (!isObject(params) || !isObject(tableKeys)) {
-    return null;
-  }
+  params = isObject(params) ? params : {};
+  tableKeys = isObject(tableKeys) ? tableKeys : {};
+
 
   var keys = Object.keys(tableKeys);
   var paramKeys = Object.keys(params);
@@ -52,7 +52,13 @@ function splitKeysAndParams(params, tableKeys) {
 }
 
 function createFilterQuery(params) {
+  if ( params === void 0 ) params = {};
+
   var paramKeys = Object.keys(params);
+  if (!paramKeys || paramKeys.length === 0) {
+    return {};
+  }
+
   return {
     FilterExpression: paramKeys.reduce(function (acc, key) {
       var maybeAnd = acc === '' ? '' : ' AND ';
@@ -180,7 +186,7 @@ function find(ref) {
 
   // If we have any params that aren't `key` attributes in the table we
   // need to use `docClient.scan` instead of `docClient.get`
-  if (isObject(scanParams) && Object.keys(scanParams).length > 0) {
+  if (Object.keys(Key).length === 0 || (isObject(scanParams) && Object.keys(scanParams).length > 0)) {
     return promiseWrapper(docClient, 'scan', Object.assign({
       TableName: TableName,
     }, createFilterQuery(scanParams)))

--- a/src/find.js
+++ b/src/find.js
@@ -7,7 +7,7 @@ export function find({ docClient, TableName, params, tableKeyDefinition }) {
 
   // If we have any params that aren't `key` attributes in the table we
   // need to use `docClient.scan` instead of `docClient.get`
-  if (isObject(scanParams) && Object.keys(scanParams).length > 0) {
+  if (Object.keys(Key).length === 0 || (isObject(scanParams) && Object.keys(scanParams).length > 0)) {
     return promiseWrapper(docClient, 'scan', Object.assign({
       TableName,
     }, createFilterQuery(scanParams)))

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import promiseWrapper from './promise-wrapper';
-import { splitKeysAndParams } from './query';
 import { isObject } from './util';
 import { find, findOne } from './find';
 import { update } from './update';

--- a/src/query.js
+++ b/src/query.js
@@ -8,9 +8,8 @@ export const valuePrefix = ':dt';
 // and another object for all other params
 // ({id: 1, name: 'pony', interests: 'ponying'}, { id: 'N' }) -> [{id: 1}, {name: 'pony', interests: 'ponying'}]
 export function splitKeysAndParams(params, tableKeys) {
-  if (!isObject(params) || !isObject(tableKeys)) {
-    return null;
-  }
+  params = isObject(params) ? params : {};
+  tableKeys = isObject(tableKeys) ? tableKeys : {};
 
   const keys = Object.keys(tableKeys);
   const paramKeys = Object.keys(params);

--- a/src/query.js
+++ b/src/query.js
@@ -23,8 +23,12 @@ export function splitKeysAndParams(params, tableKeys) {
   ];
 }
 
-export function createFilterQuery(params) {
+export function createFilterQuery(params = {}) {
   const paramKeys = Object.keys(params);
+  if (!paramKeys || paramKeys.length === 0) {
+    return {};
+  }
+
   return {
     FilterExpression: paramKeys.reduce((acc, key) => {
       const maybeAnd = acc === '' ? '' : ' AND '

--- a/src/query.test.js
+++ b/src/query.test.js
@@ -21,9 +21,10 @@ describe('splitKeysAndParams', () => {
     expect(splitKeysAndParams(paramsA, keysA)[1]).toEqual({name: 'pink pony', interests: 'ponying?'});
   });
 
-  it('Should return null on faulty input', () => {
-    expect(splitKeysAndParams('a string', keysA)).toEqual(null);
-    expect(splitKeysAndParams(paramsA, ['1', 2, 3])).toEqual(null);
+  it('Should always return an array, with empty objects on faulty input', () => {
+    const emptyRes = [{}, {}];
+    expect(splitKeysAndParams('a string', keysA)).toEqual(emptyRes);
+    expect(splitKeysAndParams(paramsA, ['1', 2, 3])[1]).toEqual(paramsA);
   });
 });
 
@@ -31,6 +32,10 @@ describe('createFilterQuery', () => {
   it('Should create filter expression out of single key/value pair', () => {
     expect(createFilterQuery({ a: 1 })).toEqual({ExpressionAttributeNames: {'#dta': 'a'}, ExpressionAttributeValues: {':dta': 1}, FilterExpression: '(#dta = :dta)'});
   });
+  it('Should return empty object oninput', () => {
+    expect(createFilterQuery({})).toEqual({});
+    expect(createFilterQuery()).toEqual({});
+  })
 });
 
 describe('constructComparisonString', () => {


### PR DESCRIPTION
`table.find({})`or `table.find()` would previously result in an error, this is the MongoDB way to select all and dynatable now behaves the same